### PR TITLE
Fix getIsSsl() in Config.php

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -47,7 +47,7 @@ abstract class Config implements IConfig
     public function getIsSsl() : bool
     {
         if (empty($this->bIsSsl)) {
-            $this->bIsSsl = (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS'] == 'on'));
+            $this->bIsSsl = (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on');
         }
         return $this->bIsSsl;
     }


### PR DESCRIPTION
Fix  `Fatal error: Uncaught TypeError: strtolower() expects parameter 1 to be string, boolean given in vendor\ph-7\cookiesession\src\Config.php on line 50`